### PR TITLE
/bin/tini should now be /sbin/tini

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,5 @@ if ! groups jenkins | grep -q docker; then
 fi
 
 # drop access to jenkins user and run jenkins entrypoint
-exec gosu jenkins /bin/tini -- /usr/local/bin/jenkins.sh "$@"
+exec gosu jenkins /sbin/tini -- /usr/local/bin/jenkins.sh "$@"
 


### PR DESCRIPTION
Updating our Ubuntu host (via apt upgrade) on 25th Jan 2019 broke our Jenkins master. This fixed it

Root case is document here: https://github.com/jenkinsci/docker/issues/629