### PR TITLE
Update docker-ce-cli version ref in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && gosu nobody true 
 
 # install docker
-ARG DOCKER_CLI_VERSION==5:18.09.0~3-0~debian-stretch
+ARG DOCKER_CLI_VERSION==5:18.09.2~3-0~debian-stretch 
 # ARG DOCKER_CLI_VERSION=
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
  && add-apt-repository \


### PR DESCRIPTION
`5:18.09.2~3-0~debian-stretch` is now available; probably built in tandem with the `docker-ce` and `containerd.io` updates which appear to be in response to CVE-2019-5736.