### PR TITLE
Create docker group if not already created in container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,13 @@ if [ "$(id -u)" = "0" ]; then
 
   # if they don't match, adjust
   if [ ! -z "$SOCK_DOCKER_GID" -a "$SOCK_DOCKER_GID" != "$CUR_DOCKER_GID" ]; then
-    groupmod -g ${SOCK_DOCKER_GID} -o docker
+    if [ -z "$CUR_DOCKER_GID" ]; then
+      # add docker group if not created
+      groupadd -g ${SOCK_DOCKER_GID} -o docker
+    else
+      # modify existing
+      groupmod -g ${SOCK_DOCKER_GID} -o docker
+    fi
   fi
   if ! groups jenkins | grep -q docker; then
     usermod -aG docker jenkins


### PR DESCRIPTION
This isn't needed, necessarily because you have the groupadd in your `Dockerfile`, however I wanted to just pickup the `entrypoint.sh` and use my existing `Dockerfile` without adding the additional `groupadd` step.  You also have the `if ! groups jenkins | grep -q docker; then` for doing the `usermod`, so figured this is just natural to update.

Up to you though!

Regards,

Eric